### PR TITLE
feat: reinstate `use-engines` option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -23,11 +23,11 @@ jobs:
 
       - name: Find Node version to use 🧐
         run: |
-          if [ '${{ github.event.inputs.node-version }}' == 'use-engines' ]; then
+          if [ '${{ inputs.node-version }}' == 'use-engines' ]; then
             echo "Using Node version from package.json"
             echo "version=$(node -p "require('./package.json').engines.node")" >> $GITHUB_OUTPUT
           else
-            echo "version=${{ github.event.inputs.node-version }}" >> $GITHUB_OUTPUT
+            echo "version=${{ inputs.node-version }}" >> $GITHUB_OUTPUT
           fi
         id: find-node-version
 

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -43,13 +43,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build 🔨
-        run: pnpm build
+        run: pnpm run --if-present build
 
       - name: Lint 🔍
-        run: pnpm lint
+        run: pnpm run --if-present lint
 
       - name: Format 🖌️
-        run: pnpm format
+        run: pnpm run --if-present format
 
       - name: Test 🧪
-        run: pnpm test
+        run: pnpm run --if-present test

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -27,29 +27,29 @@ jobs:
         run: |
           if [ $INPUT_VERSION == 'use-engines' ]; then
             echo "Using Node version from package.json"
-            echo "::set-output name=node-version::$(node -p "require('./package.json').engines.node")"
+            echo "version=$(node -p "require('./package.json').engines.node")" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=node-version::$INPUT_VERSION"
+            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
           fi
         id: find-node-version
 
       - name: Setup Node ✨
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.find-node-version.outputs.node-version }}
+          node-version: ${{ steps.find-node-version.outputs.version }}
           cache: pnpm
 
       - name: Install dependencies 📦️
         run: pnpm install --frozen-lockfile
 
       - name: Build 🔨
-        run: pnpm run --if-present build
+        run: pnpm run build --if-present
 
       - name: Lint 🔍
-        run: pnpm run --if-present lint
+        run: pnpm run lint --if-present
 
       - name: Format 🖌️
-        run: pnpm run --if-present format
+        run: pnpm run format --if-present
 
       - name: Test 🧪
-        run: pnpm run --if-present test
+        run: pnpm run test --if-present

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Find Node version to use 🧐
         run: |
-          if [ '${{ inputs.node-version }}' == 'use-engines' ]; then
+          if [ '${{ inputs.use-engines }}' == 'true' ]; then
             echo "Using Node version from package.json"
             echo "version=$(node -p "require('./package.json').engines.node")" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -3,6 +3,11 @@ name: Pnpm Typical
 on:
   workflow_call:
     inputs:
+      working-directory:
+        type: string
+        description: 'Working directory'
+        required: false
+        default: '.'
       node-version:
         type: string
         description: 'Node version. Defaults to active LTS.'
@@ -41,15 +46,20 @@ jobs:
 
       - name: Install dependencies 📦️
         run: pnpm install --frozen-lockfile
+        working-directory: ${{ github.event.inputs.working-directory }}
 
       - name: Build 🔨
         run: pnpm build
+        working-directory: ${{ github.event.inputs.working-directory }}
 
       - name: Lint 🔍
         run: pnpm lint
+        working-directory: ${{ github.event.inputs.working-directory }}
 
       - name: Format 🖌️
         run: pnpm format
+        working-directory: ${{ github.event.inputs.working-directory }}
 
       - name: Test 🧪
         run: pnpm test
+        working-directory: ${{ github.event.inputs.working-directory }}

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -3,11 +3,6 @@ name: Pnpm Typical
 on:
   workflow_call:
     inputs:
-      working-directory:
-        type: string
-        description: 'Working directory'
-        required: false
-        default: '.'
       node-version:
         type: string
         description: 'Node version. Defaults to active LTS.'
@@ -46,20 +41,15 @@ jobs:
 
       - name: Install dependencies 📦️
         run: pnpm install --frozen-lockfile
-        working-directory: ${{ github.event.inputs.working-directory }}
 
       - name: Build 🔨
         run: pnpm build
-        working-directory: ${{ github.event.inputs.working-directory }}
 
       - name: Lint 🔍
         run: pnpm lint
-        working-directory: ${{ github.event.inputs.working-directory }}
 
       - name: Format 🖌️
         run: pnpm format
-        working-directory: ${{ github.event.inputs.working-directory }}
 
       - name: Test 🧪
         run: pnpm test
-        working-directory: ${{ github.event.inputs.working-directory }}

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -28,7 +28,8 @@ jobs:
 
       - name: Find Node version to use 🧐
         run: |
-          if [ '${{ inputs.use-engines }}' == 'true' ]; then
+          USE_ENGINES=${{ inputs.use-engines }}
+          if [ $USE_ENGINES == 'true' ]; then
             echo "Using Node version from package.json"
             echo "version=$(node -p "require('./package.json').engines.node")" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -3,6 +3,11 @@ name: Pnpm Typical
 on:
   workflow_call:
     inputs:
+      use-engines:
+        type: boolean
+        description: 'Use Node version from package.json'
+        required: false
+        default: false
       node-version:
         type: string
         description: 'Node version. Defaults to active LTS.'

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: 'Node version. Defaults to active LTS.'
         required: false
-        default: 'lts/*'
+        default: lts/*
 
 jobs:
   build:
@@ -22,14 +22,12 @@ jobs:
         uses: pnpm/action-setup@v2
 
       - name: Find Node version to use 🧐
-        env:
-          INPUT_VERSION: ${{ github.event.inputs.node-version }}
         run: |
-          if [ $INPUT_VERSION == 'use-engines' ]; then
+          if [ '${{ github.event.inputs.node-version }}' == 'use-engines' ]; then
             echo "Using Node version from package.json"
             echo "version=$(node -p "require('./package.json').engines.node")" >> $GITHUB_OUTPUT
           else
-            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
+            echo "version=${{ github.event.inputs.node-version }}" >> $GITHUB_OUTPUT
           fi
         id: find-node-version
 
@@ -43,13 +41,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build 🔨
-        run: pnpm run build --if-present
+        run: pnpm run --if-present build
 
       - name: Lint 🔍
-        run: pnpm run lint --if-present
+        run: pnpm run --if-present lint
 
       - name: Format 🖌️
-        run: pnpm run format --if-present
+        run: pnpm run --if-present format
 
       - name: Test 🧪
-        run: pnpm run test --if-present
+        run: pnpm run --if-present test

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
-      - uses: pnpm/action-setup@v2
+      - name: Setup pnpm 📦️
+        uses: pnpm/action-setup@v2
 
-      - name: Find Node version to use 📦️
-        if: ${{ github.event.inputs.node-version == 'use-engines' }}
+      - name: Find Node version to use 🧐
         env:
           INPUT_VERSION: ${{ github.event.inputs.node-version }}
         run: |

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -20,10 +20,23 @@ jobs:
 
       - uses: pnpm/action-setup@v2
 
-      - name: Use Node LTS ✨
+      - name: Find Node version to use 📦️
+        if: ${{ github.event.inputs.node-version == 'use-engines' }}
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.node-version }}
+        run: |
+          if [ $INPUT_VERSION == 'use-engines' ]; then
+            echo "Using Node version from package.json"
+            echo "::set-output name=node-version::$(node -p "require('./package.json').engines.node")"
+          else
+            echo "::set-output name=node-version::$INPUT_VERSION"
+          fi
+        id: find-node-version
+
+      - name: Setup Node ✨
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version: ${{ steps.find-node-version.outputs.node-version }}
           cache: pnpm
 
       - name: Install dependencies 📦️

--- a/.github/workflows/pnpm-typical.yml
+++ b/.github/workflows/pnpm-typical.yml
@@ -1,4 +1,4 @@
-name: Pnpm Typical
+name: PNPM Typical
 
 on:
   workflow_call:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: Test Action
+
+on:
+  push:
+    branches:
+      - simenandre/fix-use-engines
+
+jobs:
+  typical-workflow:
+    name: Lint, format, test and build
+    uses: ./.github/workflows/pnpm-typical.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,8 @@ jobs:
   typical-workflow:
     name: Test
     uses: ./.github/workflows/pnpm-typical.yml
-    with:
-      working-directory: example
   typical-workflow-use-engine:
     name: Test with use-engine
     uses: ./.github/workflows/pnpm-typical.yml
     with:
-      working-directory: example
       node-version: use-engine

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   typical-workflow:
-    name: Lint, format, test and build
+    name: Test
     uses: ./.github/workflows/pnpm-typical.yml
     with:
       working-directory: example
   typical-workflow-use-engine:
-    name: Lint, format, test and build
+    name: Test with use-engine
     uses: ./.github/workflows/pnpm-typical.yml
     with:
       working-directory: example

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,3 +9,11 @@ jobs:
   typical-workflow:
     name: Lint, format, test and build
     uses: ./.github/workflows/pnpm-typical.yml
+    with:
+      working-directory: example
+  typical-workflow-use-engine:
+    name: Lint, format, test and build
+    uses: ./.github/workflows/pnpm-typical.yml
+    with:
+      working-directory: example
+      node-version: use-engine

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,4 +13,4 @@ jobs:
     name: Test with use-engine
     uses: ./.github/workflows/pnpm-typical.yml
     with:
-      node-version: use-engine
+      use-engines: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ jobs:
     uses: bjerkio/workflows/.github/workflows/pnpm-typical.yml@v1
 ```
 
-You can set `node-version` to `use-engines` to use `"engines"` from `package.json`.
+You can set `use-engines: true` to use `"engines"` from `package.json` for Node version.
 
 See [pnpm-typical.yml](.github/workflows/pnpm-typical.yml) for more details.

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-project",
+  "version": "1.0.0",
+  "packageManager": "pnpm@8.6.11"
+}

--- a/example/package.json
+++ b/example/package.json
@@ -1,5 +1,8 @@
 {
   "name": "test-project",
   "version": "1.0.0",
-  "packageManager": "pnpm@8.6.11"
+  "packageManager": "pnpm@8.6.11",
+  "engines": {
+    "node": "18.14.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-project",
+  "description": "This is not used by the workflow, it's only used for testing",
   "version": "1.0.0",
   "packageManager": "pnpm@8.6.11",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,5 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,5 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false


### PR DESCRIPTION
Trying the `use-engines` again – this time tested, and with a separate input.

Example:

```yaml
on: [push]
jobs:
  typical-workflow:
    name: Test
    uses: ./.github/workflows/pnpm-typical.yml
    with:
      use-engines: true
```